### PR TITLE
 feat: plant seeds #85 

### DIFF
--- a/app/blueprinter/bench_blueprint.rb
+++ b/app/blueprinter/bench_blueprint.rb
@@ -2,5 +2,5 @@
 
 class BenchBlueprint < Base
   # Fields
-  fields :name, :dimensions, :positions
+  fields :name, :dimensions, :positions, :greenhouse_id
 end

--- a/app/blueprinter/request_distribution_blueprint.rb
+++ b/app/blueprinter/request_distribution_blueprint.rb
@@ -2,7 +2,7 @@
 
 class RequestDistributionBlueprint < Base
   # Fields
-  fields :bench_id, :plant_stage_id, :pot_id, :pot_quantity, :area
+  fields :bench_id, :plant_stage_id, :pot_id, :pot_quantity, :positions_on_bench, :dimensions, :request_id
 
   field :greenhouse_id do |request_distribution|
     request_distribution.bench&.greenhouse_id

--- a/app/controllers/api/v1/request_distributions_controller.rb
+++ b/app/controllers/api/v1/request_distributions_controller.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class Api::V1::RequestDistributionsController < ApiController
-  before_action :set_request,      only: %i[index create]
+  before_action :set_request,      only: %i[create]
   before_action :set_distribution, only: %i[show update destroy]
 
   def index
-    request_distributions = policy_scope(@request.request_distributions)
+    request_distributions = policy_scope(RequestDistribution.all)
     authorize request_distributions
 
     render json: apply_fetcheable(request_distributions).to_blueprint
@@ -19,7 +19,6 @@ class Api::V1::RequestDistributionsController < ApiController
     authorize RequestDistribution
 
     distribution = @request.request_distributions.new(distribution_params)
-    distribution.area = compute_area(distribution)
 
     if distribution.save
       render json: distribution.to_blueprint, status: :created
@@ -30,7 +29,6 @@ class Api::V1::RequestDistributionsController < ApiController
 
   def update
     @distribution.assign_attributes(distribution_params)
-    @distribution.area = compute_area(@distribution)
 
     if @distribution.save
       render json: @distribution.to_blueprint
@@ -59,17 +57,6 @@ class Api::V1::RequestDistributionsController < ApiController
   end
 
   def distribution_params
-    params.permit(:bench_id, :plant_stage_id, :pot_id, :pot_quantity)
-  end
-
-  def compute_area(distribution)
-    return params[:area] if params[:area].present?
-
-    pot_quantity = distribution.pot_quantity
-    pot_area = distribution.pot&.area
-
-    return if pot_quantity.nil? || pot_area.nil?
-
-    pot_quantity * pot_area
+    params.permit(:bench_id, :plant_stage_id, :pot_id, :pot_quantity, positions_on_bench: [], dimensions: [])
   end
 end

--- a/app/models/bench.rb
+++ b/app/models/bench.rb
@@ -2,10 +2,7 @@
 
 class Bench < ApplicationRecord
   # Validations
-  validates :dimensions,
-            presence: true,
-            length: { is: 2, message: I18n.t('activerecord.errors.models.bench.attributes.dimensions.incorrect_size') }
-  validate :dimensions_must_be_strictly_positive
+  include ValidateDimensionsConcern
 
   validates :positions,
             presence: true,
@@ -41,14 +38,6 @@ class Bench < ApplicationRecord
     end
       errors.add(:dimensions, 'sum of distributions areas can\'t be greater than bench area')
     end
-  end
-
-  def dimensions_must_be_strictly_positive
-    return unless dimensions
-
-    return unless dimensions.any? { |d| d <= 0 }
-
-    errors.add(:dimensions, 'each dimension must be greater than 0')
   end
 
   def positions_must_be_positive

--- a/app/models/bench.rb
+++ b/app/models/bench.rb
@@ -31,8 +31,9 @@ class Bench < ApplicationRecord
   def distributions_areas_lower_than_bench_area
     return if errors[:dimensions].any?
 
+    width1, height1 = dimensions
+
     if request_distributions.any? do |request_distribution|
-      width1, height1 = dimensions
       x2, y2 = request_distribution.positions_on_bench
       width2, height2 = request_distribution.dimensions
 

--- a/app/models/concerns/validate_dimensions_concern.rb
+++ b/app/models/concerns/validate_dimensions_concern.rb
@@ -19,7 +19,7 @@ module ValidateDimensionsConcern
 
       return unless dimensions.any? { |d| d <= 0 }
 
-      errors.add(:dimensions, I18n.t('activerecord.errors.concern.attributes.dimensions.not_positive') )
+      errors.add(:dimensions, I18n.t('activerecord.errors.concern.attributes.dimensions.not_positive'))
     end
   end
 end

--- a/app/models/concerns/validate_dimensions_concern.rb
+++ b/app/models/concerns/validate_dimensions_concern.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'active_support/concern'
+
+module ValidateDimensionsConcern
+  extend ActiveSupport::Concern
+
+  included do
+    validates :dimensions,
+              presence: true,
+              length: { is: 2,
+                        message: I18n.t('activerecord.errors.concern.attributes.dimensions.incorrect_size') }
+    validate :dimensions_must_be_strictly_positive
+
+    private
+
+    def dimensions_must_be_strictly_positive
+      return unless dimensions
+
+      return unless dimensions.any? { |d| d <= 0 }
+
+      errors.add(:dimensions, I18n.t('activerecord.errors.concern.attributes.dimensions.not_positive') )
+    end
+  end
+end

--- a/app/models/request_distribution.rb
+++ b/app/models/request_distribution.rb
@@ -2,14 +2,11 @@
 
 class RequestDistribution < ApplicationRecord
   # Validations
+  include ValidateDimensionsConcern
+
   validates :pot_quantity, presence: true, numericality: { greater_than: 0 }
 
   validate :plant_stage_from_request
-
-  validates :dimensions,
-            presence: true,
-            length: { is: 2, message: I18n.t('activerecord.errors.models.bench.attributes.dimensions.incorrect_size') }
-  validate :dimensions_must_be_strictly_positive
 
   validates :positions_on_bench,
             presence: true,
@@ -60,14 +57,6 @@ class RequestDistribution < ApplicationRecord
     return if request.plant.plant_stages.include?(plant_stage)
 
     errors.add(:plant_stage, 'must be from requested plant')
-  end
-
-  def dimensions_must_be_strictly_positive
-    return unless dimensions
-
-    return unless dimensions.any? { |d| d <= 0 }
-
-    errors.add(:dimensions, 'each dimension must be greater than 0')
   end
 
   def positions_must_be_positive

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,4 @@ en:
             positions:
               incorrect_size: "should contain exactly two elements: x and y"
               not_positive: "each position must be positive"
-            request_distributions:
-              invalid_distribution: "sum of distributions areas can't be greater than bench area"
             positions_overlap: "bench overlaps with an existing bench"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,10 +20,12 @@ en:
               at_least_one: should have at least 1 plant_stage
         bench:
           attributes:
-            dimensions:
-              incorrect_size: "should contain exactly two elements: length and width"
-              not_positive: "each dimension must be greater than 0"
             positions:
               incorrect_size: "should contain exactly two elements: x and y"
               not_positive: "each position must be positive"
             positions_overlap: "bench overlaps with an existing bench"
+      concern:
+        attributes:
+          dimensions:
+            incorrect_size: "should contain exactly two elements: length and width"
+            not_positive: "each dimension must be greater than 0"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -35,8 +35,6 @@ fr:
             positions:
               incorrect_size: "doit contenir exactement deux éléments : x et y"
               not_positive: "chaque position doit être positive"
-            request_distributions:
-              invalid_distribution: "la somme des aires de distribution ne peut pas être supérieure à l'aire du banc"
             positions_overlap: "le banc chevauche un banc existant"
   date:
     abbr_day_names:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -29,13 +29,15 @@ fr:
               at_least_one: Au moins 1 request_distribution est requise
         bench:
           attributes:
-            dimensions:
-              incorrect_size: "doit contenir exactement deux éléments: longueur et largeur"
-              not_positive: "chaque dimension doit être supérieure à 0"
             positions:
               incorrect_size: "doit contenir exactement deux éléments : x et y"
               not_positive: "chaque position doit être positive"
             positions_overlap: "le banc chevauche un banc existant"
+      concern:
+        attributes:
+          dimensions:
+            incorrect_size: "doit contenir exactement deux éléments: longueur et largeur"
+            not_positive: "chaque dimension doit être supérieure à 0"
   date:
     abbr_day_names:
       - dim

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,8 +30,11 @@ Rails.application.routes.draw do
         post :refuse, on: :member
         post :cancel, on: :member
         post :complete, on: :member
-        resources :request_distributions, only: %i[index show create update destroy]
+        resources :request_distributions, only: %i[show create update destroy]
       end
+
+      resources :request_distributions, only: :index
+
       resources :buildings, only: %i[index show create update destroy], shallow: true do
         resources :greenhouses, only: %i[index show create update destroy], shallow: true do
           resources :benches, only: %i[index show create update destroy]

--- a/db/migrate/20241209193343_update_request_distributions.rb
+++ b/db/migrate/20241209193343_update_request_distributions.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class UpdateRequestDistributions < ActiveRecord::Migration[7.2]
+  def change
+    change_table :request_distributions, bulk: true do |t|
+      t.remove :area, type: :decimal
+      t.integer :positions_on_bench, array: true
+      t.integer :dimensions, array: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -115,9 +115,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_16_104204) do
     t.bigint "plant_stage_id"
     t.bigint "pot_id"
     t.integer "pot_quantity"
-    t.decimal "area"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "positions_on_bench", array: true
+    t.integer "dimensions", array: true
     t.index ["bench_id"], name: "index_request_distributions_on_bench_id"
     t.index ["plant_stage_id"], name: "index_request_distributions_on_plant_stage_id"
     t.index ["pot_id"], name: "index_request_distributions_on_pot_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -148,8 +148,9 @@ if Rails.env.development?
     requester_email: 'alice.smith@example.com',
     laboratory: 'My other lab',
     name: 'My new request',
-    plant_name: Faker::Food.vegetables,
-    plant_stage_name: 'budding',
+    plant_name: Plant.last.name,
+    plant_stage_name: Plant.last.plant_stages.last.name,
+    plant_stage: Plant.last.plant_stages.last,
     comment: Faker::Movies::LordOfTheRings.quote,
     due_date: Date.current + 2.months,
     quantity: 200
@@ -162,7 +163,8 @@ if Rails.env.development?
     plant_stage: Request.first.plant_stage,
     pot: Pot.first,
     pot_quantity: 30,
-    area: Pot.first.area * 30
+    positions_on_bench: [0, 0],
+    dimensions: [50, 50]
   )
 
   RequestDistribution.create!(
@@ -171,15 +173,19 @@ if Rails.env.development?
     plant_stage: Request.first.plant_stage,
     pot: Pot.second,
     pot_quantity: 20,
-    area: Pot.second.area * 20
+    positions_on_bench: [100, 50],
+    dimensions: [50, 20]
   )
 
   Request.first.update!(status: :accepted)
 
   RequestDistribution.create!(
     request: Request.second,
-    bench: Bench.first,
-    plant_stage: Plant.second.plant_stages.first,
-    area: 100
+    bench: Bench.second,
+    plant_stage: Request.second.plant_stage,
+    pot: Pot.second,
+    pot_quantity: 20,
+    positions_on_bench: [0, 10],
+    dimensions: [20, 30]
   )
 end

--- a/spec/acceptance/api/v1/benches_controller_spec.rb
+++ b/spec/acceptance/api/v1/benches_controller_spec.rb
@@ -87,6 +87,7 @@ resource 'Benches' do
       expect(response['name']).to eq(name)
       expect(response['dimensions']).to eq(dimensions)
       expect(response['positions']).to eq(positions)
+      expect(response['greenhouse_id']).to eq(greenhouse_id)
     end
   end
 
@@ -98,8 +99,8 @@ resource 'Benches' do
               items: { type: :integer }
 
     let(:name) { 'my square bench' }
-    let(:dimensions) { [100, 300] }
-    let(:positions) { [100, 800] }
+    let(:dimensions) { [300, 300] }
+    let(:positions) { [1200, 50] }
     let(:raw_post) { params.to_json }
 
     example 'Update a bench' do
@@ -114,6 +115,7 @@ resource 'Benches' do
       expect(bench.name).to eq(name)
       expect(bench.dimensions).to eq(dimensions)
       expect(bench.positions).to eq(positions)
+      expect(bench.greenhouse_id).to eq(greenhouse_id)
     end
   end
 

--- a/spec/acceptance/api/v1/request_distributions_controller_spec.rb
+++ b/spec/acceptance/api/v1/request_distributions_controller_spec.rb
@@ -16,7 +16,7 @@ resource 'RequestDistributions' do
   let!(:distribution) { request.request_distributions.first }
   let!(:id)           { distribution.id }
 
-  get '/api/v1/requests/:request_id/request_distributions' do
+  get '/api/v1/request_distributions' do
     parameter :'page[number]',
               "The number of the desired page\n\n" \
               "If used, additional information is returned in the response headers:\n" \
@@ -45,8 +45,8 @@ resource 'RequestDistributions' do
 
       expect(status).to eq(200)
 
-      expect(response_body).to eq(request.request_distributions.to_blueprint)
-      expect(JSON.parse(response_body).count).to eq(request.request_distributions.count)
+      expect(response_body).to eq(RequestDistribution.all.to_blueprint)
+      expect(JSON.parse(response_body).count).to eq(RequestDistribution.count)
     end
   end
 
@@ -73,16 +73,19 @@ resource 'RequestDistributions' do
               'If used, previous param `pot_id` is required',
               with_example: true,
               type: :integer
-    parameter :area,
-              "(Optional) Total area of the experiment\n" \
-              'If used, previous params `pot_id` and `pot_quantity` will be ignored',
-              with_example: true,
-              type: :number
+    parameter :positions_on_bench, 'Positions on Bench', with_example: true, type: :array, items: { type: :object }
+    parameter :dimensions, 'Dimensions', with_example: true, type: :array, items: { type: :object }
 
     let(:bench_id) { Bench.first.id }
     let(:plant_stage_id) { request.plant_stage.plant.plant_stages.first.id }
     let(:pot_id) { Pot.first.id }
     let(:pot_quantity) { 30 }
+    let(:positions_on_bench) do
+      [150, 50]
+    end
+    let(:dimensions) do
+      [10, 10]
+    end
 
     let(:raw_post) { params.to_json }
 
@@ -96,12 +99,15 @@ resource 'RequestDistributions' do
       expect(response_body).to eq(RequestDistribution.last.to_blueprint)
 
       response = JSON.parse(response_body)
+
       expect(response['bench_id']).to eq(bench_id)
       expect(response['greenhouse_id']).to eq(Bench.first.greenhouse_id)
       expect(response['plant_stage_id']).to eq(plant_stage_id)
       expect(response['pot_id']).to eq(pot_id)
       expect(response['pot_quantity']).to eq(pot_quantity)
-      expect(response['area']).not_to be_blank
+      expect(response['positions_on_bench']).to eq(positions_on_bench)
+      expect(response['dimensions']).to eq(dimensions)
+      expect(response['request_id']).to eq(request_id)
     end
   end
 
@@ -117,16 +123,19 @@ resource 'RequestDistributions' do
               'If used, previous param `pot_id` is required',
               with_example: true,
               type: :integer
-    parameter :area,
-              "(Optional) Total area of the experiment\n" \
-              'If used, previous params `pot_id` and `pot_quantity` will be ignored',
-              with_example: true,
-              type: :number
+    parameter :positions_on_bench, 'Positions on Bench', with_example: true, type: :array, items: { type: :object }
+    parameter :dimensions, 'Dimensions', with_example: true, type: :array, items: { type: :object }
 
     let(:bench_id) { Bench.last.id }
     let(:plant_stage_id) { request.plant_stage.plant.plant_stages.second.id }
     let(:pot_id) { Pot.second.id }
     let(:pot_quantity) { 20 }
+    let(:positions_on_bench) do
+      [150, 50]
+    end
+    let(:dimensions) do
+      [10, 10]
+    end
 
     let(:raw_post) { params.to_json }
 
@@ -143,7 +152,9 @@ resource 'RequestDistributions' do
       expect(distribution.plant_stage_id).to eq(plant_stage_id)
       expect(distribution.pot_id).to eq(pot_id)
       expect(distribution.pot_quantity).to eq(pot_quantity)
-      expect(distribution.area).not_to be_blank
+      expect(distribution.positions_on_bench).to eq(positions_on_bench)
+      expect(distribution.dimensions).to eq(dimensions)
+      expect(distribution.request_id).to eq(request_id)
     end
   end
 

--- a/spec/requests/api/v1/benches_spec.rb
+++ b/spec/requests/api/v1/benches_spec.rb
@@ -50,9 +50,7 @@ RSpec.describe 'Api/V1/Benches', type: :request do
           expect(status).to eq(422)
           expect(response.parsed_body.dig('error', 'message')).not_to be_blank
         end
-      end
 
-      it_behaves_like 'with authenticated grower' do
         it 'can\'t have a negative position' do
           post(
             "/api/v1/greenhouses/#{greenhouse.id}/benches",
@@ -68,11 +66,8 @@ RSpec.describe 'Api/V1/Benches', type: :request do
           expect(status).to eq(422)
           expect(response.parsed_body.dig('error', 'message')).not_to be_blank
         end
-      end
 
-      it_behaves_like 'with authenticated grower' do
-        before do
-          # Create a bench that overlaps the existing bench
+        it 'returns an error about overlapping bench' do
           post(
             "/api/v1/greenhouses/#{greenhouse.id}/benches",
             headers:,
@@ -83,9 +78,7 @@ RSpec.describe 'Api/V1/Benches', type: :request do
             },
             as: :json
           )
-        end
 
-        it 'returns an error about overlapping bench' do
           expect(status).to eq(422)
           expect(response.parsed_body.dig('error', 'message', 'positions').first)
             .to eq('bench overlaps with an existing bench')
@@ -97,42 +90,33 @@ RSpec.describe 'Api/V1/Benches', type: :request do
   describe 'PUT api/v1/benches/:id' do
     context 'when 422' do
       it_behaves_like 'with authenticated grower' do
+        it 'returns an error about overlapping bench' do
+          put(
+            "/api/v1/benches/#{bench.id}",
+            headers:,
+            params: {
+              positions: [300, 300]
+            },
+            as: :json
+          )
+
+          expect(status).to eq(422)
+          expect(response.parsed_body.dig('error', 'message', 'positions').first)
+            .to eq('bench overlaps with an existing bench')
+        end
+
         it 'can\'t have an area lower than the sum of distributions areas' do
           put(
             "/api/v1/benches/#{bench.id}",
             headers:,
             params: {
-              name: :bench_name,
-              dimensions: [25, 30],
-              positions: [10, 10]
+              dimensions: [5, 3]
             },
             as: :json
           )
 
           expect(status).to eq(422)
           expect(response.parsed_body.dig('error', 'message')).not_to be_blank
-        end
-      end
-
-      it_behaves_like 'with authenticated grower' do
-        before do
-          # Attempt to update a bench to overlap another existing bench
-          put(
-            "/api/v1/benches/#{bench.id}",
-            headers:,
-            params: {
-              name: 'Updated Bench',
-              dimensions: [500, 200],
-              positions: [bench.positions[0], bench.positions[1]] # same position as an existing bench
-            },
-            as: :json
-          )
-        end
-
-        it 'returns an error about overlapping bench' do
-          expect(status).to eq(422)
-          expect(response.parsed_body.dig('error', 'message',
-                                          'positions').first).to eq('bench overlaps with an existing bench')
         end
       end
     end

--- a/spec/requests/api/v1/request_distributions_spec.rb
+++ b/spec/requests/api/v1/request_distributions_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe 'Api/V1/RequestDistributions', type: :request do
             headers:,
             params: {
               bench_id: nil,
-              plant_stage_id: nil,
+              plant_stage_id: nil
             }
           )
 

--- a/test/fixtures/benches.yml
+++ b/test/fixtures/benches.yml
@@ -4,7 +4,7 @@ bench1:
   name: My big greenhouse - bench 1
   dimensions:
     - 200
-    - 100
+    - 200
   positions:
     - 10
     - 50
@@ -26,8 +26,8 @@ bench2:
     - 100
     - 100
   positions:
-    - 200
-    - 200
+    - 300
+    - 300
   created_at: !ruby/object:ActiveSupport::TimeWithZone
     utc: &1 2019-12-30 18:06:47.133846000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone

--- a/test/fixtures/request_distributions.yml
+++ b/test/fixtures/request_distributions.yml
@@ -6,7 +6,12 @@ request_distribution1:
   plant_stage_id: 6
   pot_id: 1
   pot_quantity: 30
-  area: !ruby/object:BigDecimal 18:0.147e4
+  dimensions:
+    - 40
+    - 40
+  positions_on_bench:
+    - 0
+    - 0
   created_at: !ruby/object:ActiveSupport::TimeWithZone
     utc: &1 2020-02-25 21:03:27.754298000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
@@ -24,7 +29,12 @@ request_distribution2:
   plant_stage_id: 6
   pot_id: 2
   pot_quantity: 20
-  area: !ruby/object:BigDecimal 18:0.16e4
+  dimensions:
+    - 40
+    - 40
+  positions_on_bench:
+    - 50
+    - 50
   created_at: !ruby/object:ActiveSupport::TimeWithZone
     utc: &1 2020-02-25 21:03:27.843552000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
@@ -40,9 +50,14 @@ request_distribution3:
   request_id: 2
   bench_id: 1
   plant_stage_id: 7
-  pot_id: 
-  pot_quantity: 
-  area: !ruby/object:BigDecimal 18:0.1e3
+  pot_id: 2
+  pot_quantity: 10
+  dimensions:
+    - 20
+    - 20
+  positions_on_bench:
+    - 100
+    - 100
   created_at: !ruby/object:ActiveSupport::TimeWithZone
     utc: &1 2020-02-25 21:04:53.101797000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
@@ -57,15 +72,16 @@ request_distribution3:
 #
 # Table name: request_distributions
 #
-#  id             :bigint           not null, primary key
-#  request_id     :bigint
-#  bench_id       :bigint
-#  plant_stage_id :bigint
-#  pot_id         :bigint
-#  pot_quantity   :integer
-#  area           :decimal(, )
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
+#  id                 :bigint           not null, primary key
+#  request_id         :bigint
+#  bench_id           :bigint
+#  plant_stage_id     :bigint
+#  pot_id             :bigint
+#  pot_quantity       :integer
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  positions_on_bench :integer          is an Array
+#  dimensions         :integer          is an Array
 #
 # Indexes
 #

--- a/test/fixtures/requests.yml
+++ b/test/fixtures/requests.yml
@@ -13,7 +13,7 @@ request1:
   status: accepted
   comment: I didn't think it would end this way.
   due_date: 2020-05-13
-  quantity: 50
+  quantity: 100
   temperature: 20
   photoperiod: 8
   created_at: !ruby/object:ActiveSupport::TimeWithZone

--- a/test/models/bench_test.rb
+++ b/test/models/bench_test.rb
@@ -60,6 +60,22 @@ class BenchTest < ActiveSupport::TestCase
     assert_includes @bench.errors[:positions], 'each position must be positive'
   end
 
+  test 'invalid with wrong number of positions' do
+    @bench.positions = [10]
+    assert_not @bench.valid?
+    assert_includes @bench.errors[:positions], 'doit contenir exactement deux éléments : x et y'
+
+    @bench.positions = [10, 20, 30]
+    assert_not @bench.valid?
+    assert_includes @bench.errors[:positions], 'doit contenir exactement deux éléments : x et y'
+  end
+
+  test 'invalid when distributions areas is lower than bench area' do
+    @bench.dimensions = [10, 20]
+    assert_not @bench.valid?
+    assert_includes @bench.errors[:dimensions], 'sum of distributions areas can\'t be greater than bench area'
+  end
+
   test 'invalid when overlapping with another bench in the same greenhouse' do
     overlapping_bench = Bench.new(
       greenhouse: @bench.greenhouse,

--- a/test/models/bench_test.rb
+++ b/test/models/bench_test.rb
@@ -37,11 +37,11 @@ class BenchTest < ActiveSupport::TestCase
   test 'invalid with non-positive dimensions' do
     @bench.dimensions = [10, -20]
     assert_not @bench.valid?
-    assert_includes @bench.errors[:dimensions], 'each dimension must be greater than 0'
+    assert_includes @bench.errors[:dimensions], 'chaque dimension doit être supérieure à 0'
 
     @bench.dimensions = [0, 30]
     assert_not @bench.valid?
-    assert_includes @bench.errors[:dimensions], 'each dimension must be greater than 0'
+    assert_includes @bench.errors[:dimensions], 'chaque dimension doit être supérieure à 0'
   end
 
   test 'invalid without position' do

--- a/test/models/request_distribution_test.rb
+++ b/test/models/request_distribution_test.rb
@@ -32,7 +32,7 @@ class RequestDistributionTest < ActiveSupport::TestCase
     assert_not_empty @request_distribution.errors[:pot_quantity]
   end
 
-  test 'invalid wit pot quantity lee than 0' do
+  test 'invalid wit pot quantity less than 0' do
     @request_distribution.pot_quantity = -1
     assert_not @request_distribution.valid?
     assert_not_empty @request_distribution.errors[:pot_quantity]

--- a/test/models/request_distribution_test.rb
+++ b/test/models/request_distribution_test.rb
@@ -69,11 +69,13 @@ class RequestDistributionTest < ActiveSupport::TestCase
   test 'invalid with wrong number of dimensions' do
     @request_distribution.dimensions = [10]
     assert_not @request_distribution.valid?
-    assert_includes @request_distribution.errors[:dimensions], 'doit contenir exactement deux éléments: longueur et largeur'
+    assert_includes @request_distribution.errors[:dimensions],
+                    'doit contenir exactement deux éléments: longueur et largeur'
 
     @request_distribution.dimensions = [10, 20, 30]
     assert_not @request_distribution.valid?
-    assert_includes @request_distribution.errors[:dimensions], 'doit contenir exactement deux éléments: longueur et largeur'
+    assert_includes @request_distribution.errors[:dimensions],
+                    'doit contenir exactement deux éléments: longueur et largeur'
   end
 
   test 'invalid with non-positive dimensions' do

--- a/test/models/request_distribution_test.rb
+++ b/test/models/request_distribution_test.rb
@@ -6,30 +6,12 @@ class RequestDistributionTest < ActiveSupport::TestCase
   # Setups
   def setup
     @request_distribution = request_distributions(:request_distribution1)
+    @plant_stage = plant_stages(:plant_stage18)
   end
 
   # Validations
   test 'valid request_distribution' do
     assert @request_distribution.valid?, @request_distribution.errors.messages
-  end
-
-  test 'valid without pot' do
-    @request_distribution.pot = nil
-    assert @request_distribution.valid?, @request_distribution.errors.messages
-  end
-
-  test 'valid without pot and pot_quantity' do
-    @request_distribution.pot = nil
-    @request_distribution.pot_quantity = nil
-    assert @request_distribution.valid?, @request_distribution.errors.messages
-  end
-
-  test 'invalid without pot_quantity if pot is present' do
-    assert @request_distribution.pot.present?
-
-    @request_distribution.pot_quantity = nil
-    assert_not @request_distribution.valid?
-    assert_not_empty @request_distribution.errors[:pot_quantity]
   end
 
   test 'invalid without bench' do
@@ -38,16 +20,32 @@ class RequestDistributionTest < ActiveSupport::TestCase
     assert_not_empty @request_distribution.errors[:bench]
   end
 
+  test 'invalid without pot' do
+    @request_distribution.pot = nil
+    assert_not @request_distribution.valid?
+    assert_not_empty @request_distribution.errors[:pot]
+  end
+
+  test 'invalid without pot quantity' do
+    @request_distribution.pot_quantity = nil
+    assert_not @request_distribution.valid?
+    assert_not_empty @request_distribution.errors[:pot_quantity]
+  end
+
+  test 'invalid wit pot quantity lee than 0' do
+    @request_distribution.pot_quantity = -1
+    assert_not @request_distribution.valid?
+    assert_not_empty @request_distribution.errors[:pot_quantity]
+
+    @request_distribution.pot_quantity = 0
+    assert_not @request_distribution.valid?
+    assert_not_empty @request_distribution.errors[:pot_quantity]
+  end
+
   test 'invalid without plant_stage' do
     @request_distribution.plant_stage = nil
     assert_not @request_distribution.valid?
     assert_not_empty @request_distribution.errors[:plant_stage]
-  end
-
-  test 'invalid without area' do
-    @request_distribution.area = nil
-    assert_not @request_distribution.valid?
-    assert_not_empty @request_distribution.errors[:area]
   end
 
   test 'invalid with plant_stage from the non-requested plant' do
@@ -55,21 +53,111 @@ class RequestDistributionTest < ActiveSupport::TestCase
     assert_not @request_distribution.valid?
     assert_not_empty @request_distribution.errors[:plant_stage]
   end
+
+  test 'invalid without enough seeds left to plant' do
+    @request_distribution.pot_quantity = 500
+    assert_not @request_distribution.valid?
+    assert_not_empty @request_distribution.errors[:pot_quantity]
+  end
+
+  test 'invalid without dimensions' do
+    @request_distribution.dimensions = nil
+    assert_not @request_distribution.valid?
+    assert_includes @request_distribution.errors[:dimensions], 'doit être rempli(e)'
+  end
+
+  test 'invalid with wrong number of dimensions' do
+    @request_distribution.dimensions = [10]
+    assert_not @request_distribution.valid?
+    assert_includes @request_distribution.errors[:dimensions], 'doit contenir exactement deux éléments: longueur et largeur'
+
+    @request_distribution.dimensions = [10, 20, 30]
+    assert_not @request_distribution.valid?
+    assert_includes @request_distribution.errors[:dimensions], 'doit contenir exactement deux éléments: longueur et largeur'
+  end
+
+  test 'invalid with non-positive dimensions' do
+    @request_distribution.dimensions = [10, -20]
+    assert_not @request_distribution.valid?
+    assert_includes @request_distribution.errors[:dimensions], 'each dimension must be greater than 0'
+
+    @request_distribution.dimensions = [0, 30]
+    assert_not @request_distribution.valid?
+    assert_includes @request_distribution.errors[:dimensions], 'each dimension must be greater than 0'
+  end
+
+  test 'invalid without positions_on_bench' do
+    @request_distribution.positions_on_bench = nil
+    assert_not @request_distribution.valid?
+    assert_includes @request_distribution.errors[:positions_on_bench], 'doit être rempli(e)'
+  end
+
+  test 'invalid with wrong number of positions_on_bench' do
+    @request_distribution.positions_on_bench = [10]
+    assert_not @request_distribution.valid?
+    assert_includes @request_distribution.errors[:positions_on_bench], 'doit contenir exactement deux éléments : x et y'
+
+    @request_distribution.positions_on_bench = [10, 20, 30]
+    assert_not @request_distribution.valid?
+    assert_includes @request_distribution.errors[:positions_on_bench], 'doit contenir exactement deux éléments : x et y'
+  end
+
+  test 'invalid with non-positive positions_on_bench' do
+    @request_distribution.positions_on_bench = [10, -20]
+    assert_not @request_distribution.valid?
+    assert_includes @request_distribution.errors[:positions_on_bench], 'each position must be positive'
+
+    @request_distribution.positions_on_bench = [-1, 30]
+    assert_not @request_distribution.valid?
+    assert_includes @request_distribution.errors[:positions_on_bench], 'each position must be positive'
+  end
+
+  test 'invalid when overlapping with another distribution in the same bench' do
+    overlapping_distribution = RequestDistribution.new(
+      request: Request.first,
+      bench: Bench.first,
+      pot: Pot.first,
+      plant_stage: @plant_stage,
+      pot_quantity: 10,
+      positions_on_bench: [0, 0],
+      dimensions: [10, 20]
+    )
+
+    assert_not overlapping_distribution.valid?
+    assert_includes overlapping_distribution.errors[:positions_on_bench],
+                    'distribution overlaps with an existing distribution'
+  end
+
+  test 'invalid when distribution outside bench' do
+    distribution = RequestDistribution.new(
+      request: Request.first,
+      bench: Bench.first,
+      pot: Pot.first,
+      plant_stage: @plant_stage,
+      pot_quantity: 10,
+      positions_on_bench: [1000, 1000],
+      dimensions: [10, 20]
+    )
+
+    assert_not distribution.valid?
+    assert_includes distribution.errors[:positions_on_bench], 'distribution exceeds the bounds of the bench'
+  end
 end
 
 # == Schema Information
 #
 # Table name: request_distributions
 #
-#  id             :bigint           not null, primary key
-#  request_id     :bigint
-#  bench_id       :bigint
-#  plant_stage_id :bigint
-#  pot_id         :bigint
-#  pot_quantity   :integer
-#  area           :decimal(, )
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
+#  id                 :bigint           not null, primary key
+#  request_id         :bigint
+#  bench_id           :bigint
+#  plant_stage_id     :bigint
+#  pot_id             :bigint
+#  pot_quantity       :integer
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  positions_on_bench :integer          is an Array
+#  dimensions         :integer          is an Array
 #
 # Indexes
 #

--- a/test/models/request_distribution_test.rb
+++ b/test/models/request_distribution_test.rb
@@ -81,11 +81,11 @@ class RequestDistributionTest < ActiveSupport::TestCase
   test 'invalid with non-positive dimensions' do
     @request_distribution.dimensions = [10, -20]
     assert_not @request_distribution.valid?
-    assert_includes @request_distribution.errors[:dimensions], 'each dimension must be greater than 0'
+    assert_includes @request_distribution.errors[:dimensions], 'chaque dimension doit être supérieure à 0'
 
     @request_distribution.dimensions = [0, 30]
     assert_not @request_distribution.valid?
-    assert_includes @request_distribution.errors[:dimensions], 'each dimension must be greater than 0'
+    assert_includes @request_distribution.errors[:dimensions], 'chaque dimension doit être supérieure à 0'
   end
 
   test 'invalid without positions_on_bench' do


### PR DESCRIPTION
The purpose of this feature is to allow the grower to be able to plant seeds of requests distribution on bench in greenhouse.

breaking change: need to modify the route of index method of `RequestDistribution`, to be able to get all distribution and draw them to the canvas.
* old : get -> `/request/:requestID/requestdistributions`
* new : get -> `/requestdistributions`