### PR TITLE
feat: add request_distribution_ids to Bench API response

### DIFF
--- a/app/blueprinter/bench_blueprint.rb
+++ b/app/blueprinter/bench_blueprint.rb
@@ -3,4 +3,8 @@
 class BenchBlueprint < Base
   # Fields
   fields :name, :dimensions, :positions, :greenhouse_id
+
+  field :request_distribution_ids do |bench|
+    bench.request_distributions.pluck(:id)
+  end
 end

--- a/spec/acceptance/api/v1/benches_controller_spec.rb
+++ b/spec/acceptance/api/v1/benches_controller_spec.rb
@@ -16,6 +16,8 @@ resource 'Benches' do
   let!(:bench) { greenhouse.benches.first }
   let!(:id) { bench.id }
 
+  let!(:request_distribution_ids) { bench.request_distributions.pluck(:id) }
+
   get '/api/v1/greenhouses/:greenhouse_id/benches' do
     parameter :'page[number]', "The number of the desired page\n\n" \
                                "If used, additional information is returned in the response headers:\n" \
@@ -88,6 +90,7 @@ resource 'Benches' do
       expect(response['dimensions']).to eq(dimensions)
       expect(response['positions']).to eq(positions)
       expect(response['greenhouse_id']).to eq(greenhouse_id)
+      expect(response['request_distribution_ids'].count).to eq(0)
     end
   end
 


### PR DESCRIPTION
This update includes request_distribution_ids in the Bench API response, allowing clients to access associated request distribution IDs. Test coverage has been added to verify the presence and correctness of this new data field.